### PR TITLE
Add Playwright config, global setup, and teardown

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,64 @@
+import { defineConfig, devices, type Project } from '@playwright/test';
+
+const projects: Project[] = [
+
+  {
+    name: 'Chrome',
+    use: {
+      browserName: 'chromium',
+      channel: 'chrome',
+      viewport: { width: 1920, height: 1080 }, 
+      deviceScaleFactor: 1,
+      isMobile: false,
+      hasTouch: false,
+      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+    },
+   },
+  {
+    name: 'Edge',
+    use: {
+      browserName: 'chromium',
+      channel: 'msedge',
+      viewport: { width: 1920, height: 1080 }, 
+      deviceScaleFactor: 1,
+      isMobile: false,
+      hasTouch: false,
+      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0',
+    },
+  },
+  {
+    name: 'Firefox',
+    use: {
+      browserName: 'firefox',
+      viewport: { width: 1920, height: 1080 }, 
+      deviceScaleFactor: 1,
+      isMobile: false,
+      hasTouch: false,
+      userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:120.0) Gecko/20100101 Firefox/120.0',
+    },
+  },
+];
+
+
+
+export default defineConfig({
+  testDir: './tests/specs',
+  timeout: 30_000,
+  retries: 0,
+  workers: 1,
+  reporter: [['html', { open: 'on-failure' }]],
+  fullyParallel: true,
+  globalSetup: './tests/fixtures/global/setup.ts',
+  globalTeardown: './tests/fixtures/global/teardown.ts',
+  use: {
+    baseURL: 'http://localhost:3000',
+    headless: false,
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    trace: 'on-first-retry',
+    testIdAttribute: 'data-qa-id',
+    actionTimeout: 10000,    
+    ignoreHTTPSErrors: true, 
+  },
+  projects: projects,
+});

--- a/tests/global/setup.ts
+++ b/tests/global/setup.ts
@@ -1,0 +1,41 @@
+import { spawn, ChildProcess } from "child_process";
+import http from "http";
+import fs from "fs";
+
+let serverProcess: ChildProcess;
+function waitForServer(url: string, timeout = 30000): Promise<void> {
+  const start = Date.now();
+  return new Promise((resolve, reject) => {
+    const check = () => {
+      if (Date.now() - start > timeout) {
+        return reject(new Error("Server did not start in time"));
+      }
+      http
+        .get(url, (res) => {
+          if (res.statusCode && res.statusCode >= 200 && res.statusCode < 500) {
+            resolve();
+          } else {
+            setTimeout(check, 500);
+          }
+        })
+        .on("error", () => setTimeout(check, 500));
+    };
+    check();
+  });
+}
+
+async function globalSetup() {
+  serverProcess = spawn("node", ["server.js"], { stdio: "inherit" });
+
+  if (serverProcess.pid) {
+    fs.writeFileSync("server.pid", serverProcess.pid.toString());
+  } else {
+    throw new Error("Failed to start the server process (pid is undefined)");
+  }
+
+  await waitForServer("http://localhost:3000");
+
+  console.log("Server is ready");
+}
+
+export default globalSetup;

--- a/tests/global/teardown.ts
+++ b/tests/global/teardown.ts
@@ -1,0 +1,14 @@
+import fs from "fs";
+
+async function globalTeardown() {
+  if (fs.existsSync("server.pid")) {
+    const pid = parseInt(fs.readFileSync("server.pid", "utf-8"));
+    try {
+      process.kill(pid);
+      fs.unlinkSync("server.pid");
+      console.log("Server stopped");
+    } catch {}
+  }
+}
+
+export default globalTeardown;


### PR DESCRIPTION
This pull request introduces the Playwright configuration file necessary for running E2E tests. It also includes global setup and teardown scripts to initialize and clean up the testing environment before and after the test suite.

These changes set up the foundation for writing and running reliable end-to-end tests in the project.

To run the tests, use the command:
  npx playwright test

No breaking changes are included in this update.
