### PR TITLE
Test/delete post

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,10 @@
   "type": "commonjs",
   "main": "server.js",
   "scripts": {
-    "start": "node ./bin/www",
-    "test": "playwright test"
-  },
+  "start": "node ./bin/www",
+  "test": "npx playwright test",
+  "test:mock": "set MOCK=true&& npx playwright test"
+},
   "dependencies": {
     "cookie-parser": "~1.4.4",
     "cors": "^2.8.5",

--- a/server.js
+++ b/server.js
@@ -16,14 +16,22 @@ app.use(cors());
 let history = [];
 
 /**
- * Cohere's generation of post title and content in JSON format
+ * Cohere's or mock generation of post title and content in JSON format
  */
-async function generatePostWithCohere(keyword) {
-  // 🔹 mock:
-  // return {
-  //   title: `AI generated title about ${keyword}`,
-  //   content: `This is a mock AI-generated blog post about: ${keyword}.`
-  // };
+const mockCallCount = {};
+
+const useMock = process.env.MOCK === 'true';
+
+async function generatePostWithCohereOrMock(keyword) {
+  if (useMock) {
+    // Mock zwracający unikalne posty
+    if (!mockCallCount[keyword]) mockCallCount[keyword] = 0;
+    mockCallCount[keyword]++;
+    return {
+      title: `Mock AI generated title about ${keyword} #${mockCallCount[keyword]}`,
+      content: `This is mock AI-generated blog post about: ${keyword} (version ${mockCallCount[keyword]}).`
+    };
+  } else {
 
   const maxRetries = 3;
   let attempt = 0;
@@ -86,6 +94,7 @@ Make sure JSON is complete and properly formatted.
       await new Promise(r => setTimeout(r, 1000)); // short delay before retry
     }
   }
+  }
 }
 
 const MAX_KEYWORD_LENGTH = 50;
@@ -105,7 +114,7 @@ app.post('/generate', async (req, res) => {
   }
 
   try {
-    const { title, content } = await generatePostWithCohere(keyword.trim());
+    const { title, content } = await generatePostWithCohereOrMock(keyword.trim());
 
     if (content.length > MAX_BLOG_LENGTH) {
       return res.status(400).json({ error: `Generated content exceeds maximum allowed (${MAX_BLOG_LENGTH} characters).` });
@@ -212,6 +221,14 @@ app.put('/history/:id', (req, res) => {
 app.get('/tags', (req, res) => {
   const uniqueTags = [...new Set(history.flatMap(entry => entry.tags))];
   res.json(uniqueTags);
+});
+
+/**
+ * Test Reset: Remove post history
+ */
+app.post('/test-reset', (req, res) => {
+  history = []; 
+  res.json({ message: 'History cleared.' });
 });
 
 app.listen(3000, () => console.log('Server running on http://localhost:3000'));

--- a/tests/fixtures/fixtures.ts
+++ b/tests/fixtures/fixtures.ts
@@ -5,6 +5,10 @@ import { PostDelete } from "./pages/post-actions/postDelete";
 import { PostGeneration } from "./pages/post-actions/postGenerate";
 import { PostList } from "./pages/post-actions/postList";
 import { PostEdit } from "./pages/post-actions/postEdit";
+import type { RequestInit, Response } from "node-fetch";
+
+const fetch = (...args: [string, RequestInit?]): Promise<Response> =>
+  import("node-fetch").then(({ default: fetch }) => fetch(...args));
 
 type Fixtures = {
   locators: ReturnType<typeof createBlogLocators>;
@@ -46,4 +50,13 @@ export const test = base.extend<Fixtures>({
     const locators = createBlogLocators(page);
     await use(locators);
   },
+});
+
+test.afterEach(async () => {
+  try {
+    await fetch("http://localhost:3000/test-reset", { method: "POST" });
+    console.log("Test data cleaned after test");
+  } catch (e) {
+    console.error("Failed to clean test data:", e);
+  }
 });

--- a/tests/fixtures/pages/post-actions/postDelete.ts
+++ b/tests/fixtures/pages/post-actions/postDelete.ts
@@ -10,6 +10,25 @@ export class PostDelete {
     this.locators = createBlogLocators(page);
   }
 
+  async clickDeletePost(keyword: string) {
+    await this.locators.postContainer
+      .filter({ hasText: keyword })
+      .locator(this.locators.btnDelete)
+      .click();
+  }
+
+  async confirmDeleteOnPopup() {
+    await this.locators.deleteConfirmModal
+      .locator(this.locators.confirmOk)
+      .click();
+  }
+
+  async cancelDeleteOnPopup() {
+    await this.locators.deleteConfirmModal
+      .locator(this.locators.confirmCancel)
+      .click();
+  }
+  
   async expectPostDeletedToastVisible() {
     await checkToast(this.locators.toastDeleted, blogTexts.postDeleted);
   }

--- a/tests/specs/e2e/delete-post.spec.ts
+++ b/tests/specs/e2e/delete-post.spec.ts
@@ -1,0 +1,40 @@
+import { expect } from "@playwright/test";
+import { test } from "../../fixtures/fixtures";
+
+test.describe("Deleting post", () => {
+  /**
+   * Runs before each test to ensure the blog page is fully loaded and generate test post
+   */
+  let keyword = "letter";
+
+  test.beforeEach(async ({ blogPage, postGeneration }) => {
+    await blogPage.pageIsLoaded();
+    await postGeneration.generatePostWithOptionalTags(keyword);
+    await postGeneration.waitForPostLoaded();
+    await postGeneration.expectPostAddedToastVisible();
+  });
+  
+  /**
+   * This test verifies that a post with a given keyword can be deleted successfully.
+   */
+  test("TC-E2E-09: Delete post successfully", async ({
+    postList,
+    postDelete,
+  }) => {
+    await postDelete.clickDeletePost(keyword);
+    await postDelete.confirmDeleteOnPopup();
+    await postDelete.expectPostDeletedToastVisible();
+
+    const data = await postList.getPostsDataByKeyword(keyword);
+    expect(data.length).toBe(0);
+  });
+
+  /**
+   * This test checks that cancelling the delete action does not remove the post.
+   */
+  test("TC-E2E-10: Cancel deletion", async ({ postList, postDelete }) => {
+    await postDelete.clickDeletePost(keyword);
+    await postDelete.cancelDeleteOnPopup();
+    await postList.verifyAddedPostData(keyword, []);
+  });
+});


### PR DESCRIPTION
This pull request contains:

- Updated the mock implementation to generate posts without calling the Cohere API, enabling faster and more reliable tests.
- Implemented a global afterEach hook that clears post data after each test, ensuring clean state and test isolation.
- Added Playwright scripts for running tests with or without mock mode, providing flexible test execution.
- Included post delete tests covering successful deletion and cancellation scenarios.